### PR TITLE
Add Cloudflare Worker deployment, Worker implementation, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,49 @@ pip install -r requirements.txt
 python main.py
 ```
 
+
+## ☁️ Deploy on Cloudflare Workers
+
+This repository now includes a Cloudflare Worker version of the bot in `worker.js`.
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Set worker secrets:
+
+```bash
+wrangler secret put TELEGRAM_BOT_TOKEN
+wrangler secret put TELEGRAM_WEBHOOK_SECRET
+```
+
+3. Deploy:
+
+```bash
+npm run deploy  # uses wrangler.toml explicitly
+```
+
+4. Configure Telegram webhook (replace placeholders):
+
+```bash
+curl -X POST "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
+  -d "url=https://<your-worker>.workers.dev" \
+  -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>" \
+  -d 'allowed_updates=["message","guest_message"]'
+```
+
+After deployment, the worker handles `/start` and `s/pattern/replacement/flags` commands from Telegram updates sent via webhook.
+
+If you are deploying from Cloudflare Pages CI, ensure the project type is **Workers** (not Pages static assets) and run `pnpx wrangler deploy --config wrangler.toml`.
+
+Guest Mode (Bot API 10.0) is also supported: if enabled in BotFather, the worker processes `guest_message` updates and replies using `answerGuestQuery`.
+
+To verify Guest Mode is enabled, call `getMe` and check that `supports_guest_queries` is `true`.
+
+Guest updates are stateless: the bot only receives the message that mentioned it and optional replied context, not full chat history or member lists.
+
 ## 📖 Usage
 
 Reply to any message with a sed-style command:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sedbot-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy --config wrangler.toml",
+    "dev": "wrangler dev --config wrangler.toml",
+    "deploy:worker": "wrangler deploy --config wrangler.toml"
+  },
+  "devDependencies": {
+    "wrangler": "^4.16.1"
+  }
+}

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,179 @@
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'POST') {
+      return new Response('OK', { status: 200 });
+    }
+
+    const secret = request.headers.get('X-Telegram-Bot-Api-Secret-Token');
+    if (env.TELEGRAM_WEBHOOK_SECRET && secret !== env.TELEGRAM_WEBHOOK_SECRET) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    let update;
+    try {
+      update = await request.json();
+    } catch {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    try {
+      if (update?.guest_message) {
+        await handleGuestUpdate(update.guest_message, env);
+        return new Response('OK', { status: 200 });
+      }
+
+      if (update?.message) {
+        await handleMessageUpdate(update.message, env);
+      }
+    } catch (error) {
+      console.error('Error processing update', error);
+    }
+
+    return new Response('OK', { status: 200 });
+  },
+};
+
+async function handleMessageUpdate(message, env) {
+  if (!message?.text) return;
+
+  if (message.text.startsWith('/start')) {
+    await sendMessage(env, message.chat.id, helpText(), {
+      reply_to_message_id: message.message_id,
+    });
+    return;
+  }
+
+  if (!message.reply_to_message?.text) return;
+
+  const parsed = parseSedCommand(message.text);
+  if (!parsed) return;
+
+  const modified = applySed(message.reply_to_message.text, parsed);
+  await sendMessage(env, message.chat.id, `Modified text:\n${modified}`, {
+    reply_to_message_id: message.reply_to_message.message_id,
+  });
+}
+
+async function handleGuestUpdate(guestMessage, env) {
+  const queryId = guestMessage?.guest_query_id;
+  const summonText = guestMessage?.text;
+  if (!queryId || !summonText) return;
+
+  try {
+    const parsed = parseSedCommand(summonText);
+    if (!parsed) {
+      await answerGuestQuery(env, queryId, 'Reply with: s/pattern/replacement/flags and include a target message.');
+      return;
+    }
+
+    const sourceText = guestMessage?.reply_to_message?.text || guestMessage?.quoted_message?.text;
+    if (!sourceText) {
+      await answerGuestQuery(env, queryId, 'I need a replied text message to transform.');
+      return;
+    }
+
+    const modified = applySed(sourceText, parsed);
+    await answerGuestQuery(env, queryId, `Modified text:\n${modified}`);
+  } catch (error) {
+    await answerGuestQuery(env, queryId, `❌ Error: ${String(error.message || error)}`);
+  }
+}
+
+function applySed(sourceText, parsed) {
+  const { pattern, replacement, flags } = parsed;
+  const jsFlags = `${flags.includes('i') ? 'i' : ''}${flags.includes('m') ? 'm' : ''}${flags.includes('g') ? 'g' : ''}`;
+  const regex = new RegExp(pattern, jsFlags);
+  return sourceText.replace(regex, replacement);
+}
+
+function helpText() {
+  return (
+    '👋 Welcome to SedBot!\n\n' +
+    'Reply to any message with: s/pattern/replacement/flags\n\n' +
+    'Flags:\n' +
+    '• g - Replace all occurrences\n' +
+    '• i - Case-insensitive matching\n' +
+    '• m - Multiline matching\n\n' +
+    'Guest mode is supported when enabled in BotFather.'
+  );
+}
+
+function parseSedCommand(command) {
+  if (!command || command[0] !== 's') return null;
+  const sep = command[1];
+  if (!sep) return null;
+
+  const sections = [];
+  let current = '';
+  let escaped = false;
+
+  for (let i = 2; i < command.length; i += 1) {
+    const ch = command[i];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaped = true;
+      current += ch;
+      continue;
+    }
+
+    if (ch === sep) {
+      sections.push(current);
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+
+  sections.push(current);
+  if (sections.length < 2) return null;
+
+  const pattern = sections[0];
+  const replacement = sections[1];
+  const flags = sections[2] || '';
+
+  if (/[^gim]/.test(flags)) {
+    throw new Error('Unsupported flags. Use only g, i, m');
+  }
+
+  return { pattern, replacement, flags };
+}
+
+async function sendMessage(env, chatId, text, extra = {}) {
+  const endpoint = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const payload = {
+    chat_id: chatId,
+    text,
+    ...extra,
+  };
+
+  await telegramCall(endpoint, payload);
+}
+
+async function answerGuestQuery(env, guestQueryId, text) {
+  const endpoint = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/answerGuestQuery`;
+  const payload = {
+    guest_query_id: guestQueryId,
+    text,
+  };
+
+  await telegramCall(endpoint, payload);
+}
+
+async function telegramCall(endpoint, payload) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Telegram API error (${response.status}): ${body}`);
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "sedbot-worker"
+main = "worker.js"
+compatibility_date = "2026-05-13"
+
+[observability]
+enabled = true


### PR DESCRIPTION
### Motivation

- Provide a serverless Cloudflare Workers deployment option so the bot can run without a persistent Python process. 
- Support Telegram webhook-based operation including Bot API 10.0 Guest Mode so the bot can process `guest_message` updates.

### Description

- Add a Cloudflare Worker implementation in `worker.js` that handles POST webhook updates, validates `X-Telegram-Bot-Api-Secret-Token`, parses `s/pattern/replacement/flags` commands with `parseSedCommand`, performs transformations with `applySed`, and replies via `sendMessage` and `answerGuestQuery`.
- Add `package.json` with `deploy` and `dev` scripts that call `wrangler` and add `wrangler.toml` with `name`, `main`, `compatibility_date`, and observability enabled.
- Update `README.md` with deployment instructions for Workers including commands `npm install`, `wrangler secret put TELEGRAM_BOT_TOKEN`, `wrangler secret put TELEGRAM_WEBHOOK_SECRET`, and `npm run deploy`, and an example `curl` to call `setWebhook`.
- Implement Guest Mode handling to reply to `guest_message` updates and provide guidance about `supports_guest_queries` and stateless guest updates.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044af5d72083318923330ba98fbd23)