### PR TITLE
Integrate grammY for Telegram webhook handling and add grammy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "wrangler": "^4.16.1",
+    "@cloudflare/workers-types": "^4.20260510.0",
     "typescript": "^5.6.3",
-    "@cloudflare/workers-types": "^4.20260510.0"
+    "wrangler": "^4.16.1"
+  },
+  "dependencies": {
+    "grammy": "^1.42.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      grammy:
+        specifier: ^1.42.0
+        version: 1.42.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260510.0
@@ -229,6 +233,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@grammyjs/types@3.26.0':
+    resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -392,12 +399,25 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -411,10 +431,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  grammy@1.42.0:
+    resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -424,6 +452,18 @@ packages:
     resolution: {integrity: sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -444,6 +484,9 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -458,6 +501,12 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   workerd@1.20260508.1:
     resolution: {integrity: sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw==}
@@ -606,6 +655,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@grammyjs/types@3.26.0': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -727,9 +778,17 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   blake3-wasm@2.1.5: {}
 
   cookie@1.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   detect-libc@2.1.2: {}
 
@@ -764,8 +823,20 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  event-target-shim@5.0.1: {}
+
   fsevents@2.3.3:
     optional: true
+
+  grammy@1.42.0:
+    dependencies:
+      '@grammyjs/types': 3.26.0
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   kleur@4.1.5: {}
 
@@ -780,6 +851,12 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  ms@2.1.3: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   path-to-regexp@6.3.0: {}
 
@@ -820,6 +897,8 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  tr46@0.0.3: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -830,6 +909,13 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   workerd@1.20260508.1:
     optionalDependencies:

--- a/worker.ts
+++ b/worker.ts
@@ -1,18 +1,14 @@
+import { Bot, webhookCallback } from 'grammy';
+
 interface Env {
   TELEGRAM_BOT_TOKEN: string;
   TELEGRAM_WEBHOOK_SECRET?: string;
 }
 
-interface TelegramChat {
-  id: number;
-}
-
 interface TelegramMessage {
   message_id: number;
   text?: string;
-  chat: TelegramChat;
   reply_to_message?: {
-    message_id: number;
     text?: string;
   };
 }
@@ -29,7 +25,6 @@ interface GuestMessage {
 }
 
 interface TelegramUpdate {
-  message?: TelegramMessage;
   guest_message?: GuestMessage;
 }
 
@@ -39,9 +34,7 @@ interface ParsedSedCommand {
   flags: string;
 }
 
-interface SendMessageExtra {
-  reply_to_message_id?: number;
-}
+const botCache = new Map<string, Bot>();
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -56,7 +49,7 @@ export default {
 
     let update: TelegramUpdate;
     try {
-      update = (await request.json()) as TelegramUpdate;
+      update = (await request.clone().json()) as TelegramUpdate;
     } catch {
       return new Response('Bad Request', { status: 400 });
     }
@@ -67,36 +60,47 @@ export default {
         return new Response('OK', { status: 200 });
       }
 
-      if (update.message) {
-        await handleMessageUpdate(update.message, env);
-      }
+      const bot = getBot(env);
+      const handler = webhookCallback(bot, 'cloudflare-mod');
+      return await handler(request);
     } catch (error: unknown) {
       console.error('Error processing update', error);
+      return new Response('OK', { status: 200 });
     }
-
-    return new Response('OK', { status: 200 });
   },
 };
 
-async function handleMessageUpdate(message: TelegramMessage, env: Env): Promise<void> {
-  if (!message.text) return;
+function getBot(env: Env): Bot {
+  const cached = botCache.get(env.TELEGRAM_BOT_TOKEN);
+  if (cached) return cached;
 
-  if (message.text.startsWith('/start')) {
-    await sendMessage(env, message.chat.id, helpText(), {
-      reply_to_message_id: message.message_id,
+  const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
+
+  bot.command('start', async (ctx) => {
+    await ctx.reply(helpText(), {
+      reply_parameters: { message_id: ctx.msg.message_id },
     });
-    return;
-  }
-
-  if (!message.reply_to_message?.text) return;
-
-  const parsed = parseSedCommand(message.text);
-  if (!parsed) return;
-
-  const modified = applySed(message.reply_to_message.text, parsed);
-  await sendMessage(env, message.chat.id, `Modified text:\n${modified}`, {
-    reply_to_message_id: message.reply_to_message.message_id,
   });
+
+  bot.on('message:text', async (ctx) => {
+    const message = ctx.message as TelegramMessage;
+    if (!message.reply_to_message?.text) return;
+
+    const parsed = parseSedCommand(message.text ?? '');
+    if (!parsed) return;
+
+    const modified = applySed(message.reply_to_message.text, parsed);
+    await ctx.reply(`Modified text:\n${modified}`, {
+      reply_parameters: { message_id: message.message_id },
+    });
+  });
+
+  bot.catch((error) => {
+    console.error('grammY error', error.error);
+  });
+
+  botCache.set(env.TELEGRAM_BOT_TOKEN, bot);
+  return bot;
 }
 
 async function handleGuestUpdate(guestMessage: GuestMessage, env: Env): Promise<void> {
@@ -192,17 +196,6 @@ function parseSedCommand(command: string): ParsedSedCommand | null {
   return { pattern, replacement, flags };
 }
 
-async function sendMessage(env: Env, chatId: number, text: string, extra: SendMessageExtra = {}): Promise<void> {
-  const endpoint = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`;
-  const payload = {
-    chat_id: chatId,
-    text,
-    ...extra,
-  };
-
-  await telegramCall(endpoint, payload);
-}
-
 async function answerGuestQuery(env: Env, guestQueryId: string, text: string): Promise<void> {
   const endpoint = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/answerGuestQuery`;
   const payload = {
@@ -213,7 +206,7 @@ async function answerGuestQuery(env: Env, guestQueryId: string, text: string): P
   await telegramCall(endpoint, payload);
 }
 
-async function telegramCall(endpoint: string, payload: Record<string, number | string>): Promise<void> {
+async function telegramCall(endpoint: string, payload: Record<string, string>): Promise<void> {
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "sedbot"
-main = "worker.js"
+main = "worker.ts"
 compatibility_date = "2026-05-13"
 
 [observability]


### PR DESCRIPTION
### Motivation
- Replace ad-hoc Telegram API calls and manual update routing with the grammY framework to simplify webhook handling and command/message processing.
- Add the official `grammy` package so the worker can use higher-level bot abstractions and reduce manual HTTP calls to send replies.

### Description
- Added `grammy` to `package.json` `dependencies` and updated `pnpm-lock.yaml` to include its transitive dependencies and related packages.
- Rewrote `worker.ts` to instantiate a `Bot` via `grammy`, use `webhookCallback(bot, 'cloudflare-mod')` to handle incoming webhook requests, and cache bot instances in `botCache` keyed by token via `getBot`.
- Implemented `start` command and a `message:text` handler via `grammy` that parse and apply the sed-style command and reply with `ctx.reply`, and added a `bot.catch` handler for runtime errors.
- Kept guest message handling in `handleGuestUpdate`, removed the manual `sendMessage` helper, changed the JSON parsing call to `request.clone().json()`, and tightened `telegramCall` payload typing to `Record<string, string>`.

### Testing
- Ran `npm run typecheck` and the TypeScript typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0489e5b04883319b3d53345013d64f)